### PR TITLE
Some changes for "buttons"

### DIFF
--- a/templates/admin/user/edit.tmpl
+++ b/templates/admin/user/edit.tmpl
@@ -214,6 +214,6 @@
 			<p class="help">{{.locale.Tr "admin.users.purge_help"}}</p>
 		</div>
 		{{template "base/delete_modal_actions" .}}
-</form>
+	</form>
 </div>
 {{template "base/footer" .}}

--- a/templates/repo/activity.tmpl
+++ b/templates/repo/activity.tmpl
@@ -5,11 +5,13 @@
 		<h2 class="ui header"><time data-format="date" datetime="{{.DateFrom}}">{{.DateFrom}}</time> - <time data-format="date" datetime="{{.DateUntil}}">{{.DateUntil}}</time>
 			<div class="ui right">
 				<!-- Period -->
-				<div class="ui basic compact button floating dropdown jump filter">
-					<span class="text">
-						{{.locale.Tr "repo.activity.period.filter_label"}} <strong>{{.PeriodText}}</strong>
-						{{svg "octicon-triangle-down" 14 "dropdown icon"}}
-					</span>
+				<div class="ui floating dropdown jump filter">
+					<div class="ui basic compact button">
+						<span class="text">
+							{{.locale.Tr "repo.activity.period.filter_label"}} <strong>{{.PeriodText}}</strong>
+							{{svg "octicon-triangle-down" 14 "dropdown icon"}}
+						</span>
+					</div>
 					<div class="menu">
 						<a class="{{if eq .Period "daily"}}active {{end}}item" href="{{$.RepoLink}}/activity/daily">{{.locale.Tr "repo.activity.period.daily"}}</a>
 						<a class="{{if eq .Period "halfweekly"}}active {{end}}item" href="{{$.RepoLink}}/activity/halfweekly">{{.locale.Tr "repo.activity.period.halfweekly"}}</a>

--- a/templates/repo/cite/cite_modal.tmpl
+++ b/templates/repo/cite/cite_modal.tmpl
@@ -15,7 +15,7 @@
 		</div>
 	</div>
 	<div class="actions">
-		<button class="ui black deny button">
+		<button class="ui black cancel button">
 			{{.locale.Tr "cancel"}}
 		</button>
 	</div>

--- a/templates/repo/diff/compare.tmpl
+++ b/templates/repo/diff/compare.tmpl
@@ -43,10 +43,10 @@
 	<div class="ui segment choose branch">
 		<a href="{{$.HeadRepo.Link}}/compare/{{PathEscapeSegments $.HeadBranch}}{{$.CompareSeparator}}{{if not $.PullRequestCtx.SameRepo}}{{PathEscape $.BaseName}}/{{PathEscape $.Repository.Name}}:{{end}}{{PathEscapeSegments $.BaseBranch}}" title="{{.locale.Tr "repo.pulls.switch_head_and_base"}}">{{svg "octicon-git-compare"}}</a>
 		<div class="ui floating filter dropdown" data-no-results="{{.locale.Tr "repo.pulls.no_results"}}">
-			<button class="ui basic small button">
+			<div class="ui basic small button">
 				<span class="text">{{if $.PageIsComparePull}}{{.locale.Tr "repo.pulls.compare_base"}}{{else}}{{.locale.Tr "repo.compare.compare_base"}}{{end}}: {{$BaseCompareName}}:{{$.BaseBranch}}</span>
 				{{svg "octicon-triangle-down" 14 "dropdown icon"}}
-			</button>
+			</div>
 			<div class="menu">
 				<div class="ui icon search input">
 					<i class="icon gt-df gt-ac gt-jc gt-m-0">{{svg "octicon-filter" 16}}</i>
@@ -112,10 +112,10 @@
 		</div>
 		<a href="{{.RepoLink}}/compare/{{PathEscapeSegments .BaseBranch}}{{.OtherCompareSeparator}}{{if not $.PullRequestCtx.SameRepo}}{{PathEscape $.HeadUser.Name}}/{{PathEscape $.HeadRepo.Name}}:{{end}}{{PathEscapeSegments $.HeadBranch}}" title="{{.locale.Tr "repo.pulls.switch_comparison_type"}}">{{.CompareSeparator}}</a>
 		<div class="ui floating filter dropdown">
-			<button class="ui basic small button">
+			<div class="ui basic small button">
 				<span class="text">{{if $.PageIsComparePull}}{{.locale.Tr "repo.pulls.compare_compare"}}{{else}}{{.locale.Tr "repo.compare.compare_head"}}{{end}}: {{$HeadCompareName}}:{{$.HeadBranch}}</span>
 				{{svg "octicon-triangle-down" 14 "dropdown icon"}}
-			</button>
+			</div>
 			<div class="menu">
 				<div class="ui icon search input">
 					<i class="icon gt-df gt-ac gt-jc gt-m-0">{{svg "octicon-filter" 16}}</i>

--- a/templates/repo/issue/branch_selector_field.tmpl
+++ b/templates/repo/issue/branch_selector_field.tmpl
@@ -6,10 +6,10 @@
 </form>
 
 <div class="ui {{if not .HasIssuesOrPullsWritePermission}}disabled{{end}} floating filter select-branch dropdown" data-no-results="{{.locale.Tr "repo.pulls.no_results"}}">
-	<button class="ui basic small button">
+	<div class="ui basic small button">
 		<span class="text branch-name">{{if .Reference}}{{$.RefEndName}}{{else}}{{.locale.Tr "repo.issues.no_ref"}}{{end}}</span>
 		{{if .HasIssuesOrPullsWritePermission}}{{svg "octicon-triangle-down" 14 "dropdown icon"}}{{end}}
-	</button>
+	</div>
 	<div class="menu">
 		<div class="ui icon search input">
 			<i class="icon gt-df gt-ac gt-jc gt-m-0">{{svg "octicon-filter" 16}}</i>

--- a/templates/repo/issue/view_title.tmpl
+++ b/templates/repo/issue/view_title.tmpl
@@ -61,16 +61,16 @@
 			{{end}}
 			<span id="pull-desc-edit" class="gt-hidden">
 				<div class="ui floating filter dropdown">
-					<button class="ui basic small button">
+					<div class="ui basic small button">
 						<span class="text">{{.locale.Tr "repo.pulls.compare_compare"}}: {{$.HeadTarget}}</span>
-					</button>
+					</div>
 				</div>
 				{{svg "octicon-arrow-right"}}
 				<div class="ui floating filter dropdown" data-no-results="{{.locale.Tr "repo.pulls.no_results"}}">
-					<button class="ui basic small button">
+					<div class="ui basic small button">
 						<span class="text" id="pull-target-branch" data-basename="{{$.BaseName}}" data-branch="{{$.BaseBranch}}">{{.locale.Tr "repo.pulls.compare_base"}}: {{$.BaseName}}:{{$.BaseBranch}}</span>
 						{{svg "octicon-triangle-down" 14 "dropdown icon"}}
-					</button>
+					</div>
 					<div class="menu">
 						<div class="ui icon search input">
 							<i class="icon gt-df gt-ac gt-jc gt-m-0">{{svg "octicon-filter" 16}}</i>

--- a/templates/repo/settings/webhook/base_list.tmpl
+++ b/templates/repo/settings/webhook/base_list.tmpl
@@ -2,7 +2,7 @@
 	{{.Title}}
 	<div class="ui right">
 		<div class="ui floating1 jump dropdown">
-			<button class="ui primary tiny button">{{.locale.Tr "repo.settings.add_webhook"}}</button>
+			<div class="ui primary tiny button">{{.locale.Tr "repo.settings.add_webhook"}}</div>
 			<div class="menu">
 				<a class="item" href="{{.BaseLinkNew}}/gitea/new">
 					<img width="20" height="20" src="{{AssetUrlPrefix}}/img/gitea.svg">{{.locale.Tr "repo.settings.web_hook_name_gitea"}}

--- a/templates/repo/wiki/view.tmpl
+++ b/templates/repo/wiki/view.tmpl
@@ -7,13 +7,13 @@
 			<div class="gt-df gt-ac">
 				<div class="choose page">
 					<div class="ui floating filter dropdown" data-no-results="{{.locale.Tr "repo.pulls.no_results"}}">
-						<button class="ui basic small button">
+						<div class="ui basic small button">
 							<span class="text">
 								{{.locale.Tr "repo.wiki.page"}}:
 								<strong>{{$title}}</strong>
 							</span>
 							{{svg "octicon-triangle-down" 14 "dropdown icon"}}
-						</button>
+						</div>
 						<div class="menu">
 							<div class="ui icon search input">
 								<i class="icon gt-df gt-ac gt-jc gt-m-0">{{svg "octicon-filter" 16}}</i>

--- a/templates/user/settings/security/accountlinks.tmpl
+++ b/templates/user/settings/security/accountlinks.tmpl
@@ -3,7 +3,7 @@
 	{{if .OrderedOAuth2Names}}
 		<div class="ui right">
 			<div class="ui dropdown">
-				<button class="ui primary tiny button">{{.locale.Tr "settings.link_account"}}</button>
+				<div class="ui primary tiny button">{{.locale.Tr "settings.link_account"}}</div>
 				<div class="menu">
 					{{range $key := .OrderedOAuth2Names}}
 						{{$provider := index $.OAuth2Providers $key}}

--- a/web_src/js/features/admin/common.js
+++ b/web_src/js/features/admin/common.js
@@ -198,7 +198,8 @@ export function initAdminCommon() {
           break;
       }
     });
-    $('#delete-selection').on('click', function () {
+    $('#delete-selection').on('click', function (e) {
+      e.preventDefault();
       const $this = $(this);
       $this.addClass('loading disabled');
       const ids = [];

--- a/web_src/js/features/aria.js
+++ b/web_src/js/features/aria.js
@@ -96,9 +96,11 @@ function attachOneDropdownAria($dropdown) {
   $dropdown.on('keyup', (e) => { if (e.key.startsWith('Arrow')) deferredRefreshAria(); });
 }
 
-export function initCancelButtons(rootElement=document) {
-  // Only cancel buttons should have the 'cancel' class, and these buttons should not submit an underlying form, so set 'type="button"' for them
-  rootElement.querySelectorAll('.cancel').forEach(cancelButton => cancelButton.setAttribute('type', 'button'));
+export function initCancelButtons(rootElement = document) {
+  // Possible Solution 3:
+  // There are many "cancel button" elements in modal dialogs, Fomantic UI expects they are button-like elements but never submit a form.
+  // However, Gitea misused the modal dialog and put the cancel buttons inside forms, so set 'type="button"' for them to prevent the form submission.
+  rootElement.querySelectorAll('.ui.modal form .ui.cancel.button').forEach(cancelButton => cancelButton.setAttribute('type', 'button'));
 }
 
 export function attachDropdownAria($dropdowns) {

--- a/web_src/js/features/aria.js
+++ b/web_src/js/features/aria.js
@@ -100,7 +100,9 @@ export function initCancelButtons(rootElement = document) {
   // Possible Solution 3:
   // There are many "cancel button" elements in modal dialogs, Fomantic UI expects they are button-like elements but never submit a form.
   // However, Gitea misused the modal dialog and put the cancel buttons inside forms, so set 'type="button"' for them to prevent the form submission.
-  rootElement.querySelectorAll('.ui.modal form .ui.cancel.button').forEach(cancelButton => cancelButton.setAttribute('type', 'button'));
+  // And there are a few cancel buttons in non-modal forms.
+  // Possible Solution 2 is better, because there are some dynamically created forms (eg: the "Edit Issue Content")
+  rootElement.querySelectorAll('form .ui.cancel.button').forEach(cancelButton => cancelButton.setAttribute('type', 'button'));
 }
 
 export function attachDropdownAria($dropdowns) {

--- a/web_src/js/features/common-global.js
+++ b/web_src/js/features/common-global.js
@@ -202,7 +202,8 @@ export function initGlobalDropzone() {
 }
 
 export function initGlobalLinkActions() {
-  function showDeletePopup() {
+  function showDeletePopup(e) {
+    e.preventDefault();
     const $this = $(this);
     const dataArray = $this.data();
     let filter = '';
@@ -243,10 +244,10 @@ export function initGlobalLinkActions() {
         });
       }
     }).modal('show');
-    return false;
   }
 
-  function showAddAllPopup() {
+  function showAddAllPopup(e) {
+    e.preventDefault();
     const $this = $(this);
     let filter = '';
     if ($this.attr('id')) {
@@ -272,7 +273,6 @@ export function initGlobalLinkActions() {
         });
       }
     }).modal('show');
-    return false;
   }
 
   function linkAction(e) {
@@ -318,6 +318,13 @@ export function initGlobalLinkActions() {
 }
 
 export function initGlobalButtons() {
+  // Possible Solution 2:
+  // There are many "cancel button" elements in modal dialogs, Fomantic UI expects they are button-like elements but never submit a form.
+  // However, Gitea misused the modal dialog and put the cancel buttons inside forms, so we must prevent the form submission.
+  $(document).on('click', '.ui.modal form .ui.cancel.button', event => {
+    event.preventDefault();
+  });
+
   $('.show-panel.button').on('click', function (event) {
     event.preventDefault();
     showElem($(this).data('panel'));

--- a/web_src/js/features/common-global.js
+++ b/web_src/js/features/common-global.js
@@ -321,7 +321,8 @@ export function initGlobalButtons() {
   // Possible Solution 2:
   // There are many "cancel button" elements in modal dialogs, Fomantic UI expects they are button-like elements but never submit a form.
   // However, Gitea misused the modal dialog and put the cancel buttons inside forms, so we must prevent the form submission.
-  $(document).on('click', '.ui.modal form .ui.cancel.button', event => {
+  // And there are a few cancel buttons in non-modal forms, and there are some dynamically created forms (eg: the "Edit Issue Content")
+  $(document).on('click', 'form .ui.cancel.button', event => {
     event.preventDefault();
   });
 

--- a/web_src/js/features/common-issue.js
+++ b/web_src/js/features/common-issue.js
@@ -34,6 +34,7 @@ export function initCommonIssue() {
   });
 
   $('.issue-action').on('click', async function (e) {
+    e.preventDefault();
     let action = this.getAttribute('data-action');
     let elementId = this.getAttribute('data-element-id');
     const url = this.getAttribute('data-url');

--- a/web_src/js/features/repo-issue.js
+++ b/web_src/js/features/repo-issue.js
@@ -231,6 +231,7 @@ export function initRepoIssueStatusButton() {
     $statusButton.text($statusButton.data(value.length === 0 ? 'status' : 'status-and-comment'));
   });
   $statusButton.on('click', () => {
+    e.preventDefault();
     $('#status').val($statusButton.data('status-val'));
     $('#comment-form').trigger('submit');
   });

--- a/web_src/js/features/repo-issue.js
+++ b/web_src/js/features/repo-issue.js
@@ -230,7 +230,7 @@ export function initRepoIssueStatusButton() {
     const value = easyMDE?.value() || $(this).val();
     $statusButton.text($statusButton.data(value.length === 0 ? 'status' : 'status-and-comment'));
   });
-  $statusButton.on('click', () => {
+  $statusButton.on('click', (e) => {
     e.preventDefault();
     $('#status').val($statusButton.data('status-val'));
     $('#comment-form').trigger('submit');

--- a/web_src/js/features/repo-legacy.js
+++ b/web_src/js/features/repo-legacy.js
@@ -412,7 +412,8 @@ async function onEditContent(event) {
       $saveButton.trigger('click');
     });
 
-    $editContentZone.find('.cancel.button').on('click', () => {
+    $editContentZone.find('.cancel.button').on('click', (e) => {
+      e.preventDefault();
       showElem($renderContent);
       hideElem($editContentZone);
       if (dz) {


### PR DESCRIPTION
See the commit log, I did my best to group the changes.

Major:

* Demo for possible solution 2&3 (feel free to choose one)
    * Solution 2: `$(document).on('click', 'form .ui.cancel.button'`
    * Solution 3: `querySelectorAll('form .ui.cancel.button')`
    * I think we should use accurate selectors to avoid side effect: we only need to process the buttons inside a form.
    * Solution 2 seems better, because there are dynamically created forms, eg: Edit Issue Content.
* Revert buttons in dropdowns
    *  The "buttons" in dropdowns are for display-only, and they shouldn't be focused, otherwise it breaks the dropdown's focusing behavior.
    * So I changed them back to the old code, to prevent breaking. IMO they won't be a problem because they don't really need to be focused or handle events.
* Rename `deny button` to `cancel button`, they are the same in Fomantic Modal: `deny: '.actions .negative, .actions .deny, .actions .cancel'`


Feel free to take what you like and discard the unnecessary changes.